### PR TITLE
Add extension detection for Vale

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,34 @@ otherwise you can call `flymake-vale-maybe-load` like the snippet below.
 ```el
 (add-hook 'find-file-hook 'flymake-vale-maybe-load)
 ```
+
+## File Extensions
+
+Vale has support for text markup formats ([including org-mode
+support](https://github.com/errata-ai/vale/issues/330) soon!), but it
+needs to know the file extension so it can parse the content of the
+file, while ignoring the parts we don't want to check. By default, if
+the buffer is a file buffer, `flymake-vale` will use the file's
+extension.
+
+You can set the extension manually with the `flymake-vale-file-ext`
+buffer local variable, and of particular note: you can combine this
+with a hook to provide flymake-vale support for new buffers.
+
+```el
+(add-hook 'org-mode-hook '(lambda ()
+  (setq flymake-vale-file-ext ".org")
+  (flymake-vale-load)))
+
+(add-hook 'org-msg-mode-hook '(lambda ()
+  (setq flymake-vale-file-ext ".org")
+  (flymake-vale-load)))
+
+(add-hook 'markdown-mode-hook '(lambda ()
+  (setq flymake-vale-file-ext ".md")
+  (flymake-vale-load)))
+
+(add-hook 'html-mode-hook '(lambda ()
+  (setq flymake-vale-file-ext ".html")
+  (flymake-vale-load)))
+```


### PR DESCRIPTION
Use either the file name extension, or the value of `flymake-vale-file-ext`.

Fixes https://github.com/tpeacock19/flymake-vale/issues/2.

![image](https://user-images.githubusercontent.com/101739/177022700-65bf7007-6a5d-4c82-9c31-f956a8892db8.png)


### TODO:

- [x] Create a buffer-local variable that can be set by the user and will be checked before we try to determine the extension from the buffer-file-name.