### PR TITLE
Remove debug message

### DIFF
--- a/flymake-vale.el
+++ b/flymake-vale.el
@@ -210,7 +210,6 @@ Converts output into a sequence of flymake error structs."
 	       ((and proc-current (stringp err))
 		(funcall report-fn :panic :explanation err))
 	       (proc-current
-		(message " current buffer: %s" (current-buffer))
 		(funcall report-fn (flymake-vale--output-to-errors
 				    output source start)
                          :region (cons start end))


### PR DESCRIPTION
I'm guessing this was meant as a debug message since it triggers on every run of flymake, cluttering up *Messages*