### PR TITLE
Pass diagnostic description as list to fit Flymake columns

### DIFF
--- a/flymake-vale.el
+++ b/flymake-vale.el
@@ -9,7 +9,7 @@
 ;; Version: 0.0.2
 ;; Keywords:
 ;; Homepage: https://github.com/tpeacock19/new
-;; Package-Requires: ((emacs "27.1") (flymake "0.22")
+;; Package-Requires: ((emacs "27.1") (flymake "1.4.1")
 ;;  (let-alist "1.0.4") (compat "29.1.4.4"))
 ;;
 ;; This file is not part of GNU Emacs.

--- a/flymake-vale.el
+++ b/flymake-vale.el
@@ -139,8 +139,9 @@ The extension is necessary for Vale's format-sensitive parsing.")
                  (car pos) (cdr pos)
                  (assoc-default .Severity flymake-vale--level-map
                                 'string-equal 'error)
-                 (format "%s [vale:%s:%s]" .Message
-                         (car check) (cadr check)))
+                 (list (format "vale:%s" (car check))
+                       (cadr check)
+                       .Message))
                 check-list))))
     check-list))
 


### PR DESCRIPTION
Flymake supports the diagnostic info being passed as a list of `'(origin code msg)`  which then maps to the columns.

> INFO is a description of the problem detected.  It may be a string, or
list (ORIGIN CODE MESSAGE) appropriately categorizing and describing the
diagnostic.  ORIGIN may be a string or nil.  CODE maybe be a string, a
number or nil.  MESSAGE must be a string.

This changes it to use this functionality and end up consistent with Eglot LSP outputs
